### PR TITLE
Update ctprotein.py

### DIFF
--- a/camparitraj/ctprotein.py
+++ b/camparitraj/ctprotein.py
@@ -4633,7 +4633,7 @@ class CTProtein:
         
         for i in range(window_size - 1, n_residues):
                     
-            ctutils.status_message("On range %i" % i, verbose)
+            ctio.status_message("On range %i" % i, verbose)
 
             # get radius of gyration (now by default is in Angstroms
             # - in previous versions we performed a conversion here)


### PR DESCRIPTION
Replaced `ctuils.status_message()` with `ctio.status_message()` in `ctprotein.CTProtein.get_local_collapse()`.

## Description
Running `get_local_collapse` without this patch crashes since `status_message` does not exist in `ctuils`.
