### PR TITLE
Revision to `ssutils.set_numpy_threads`

### DIFF
--- a/soursop/ssutils.py
+++ b/soursop/ssutils.py
@@ -1,10 +1,10 @@
 
-##     _____  ____  _    _ _____   _____  ____  _____  
-##   / ____|/ __ \| |  | |  __ \ / ____|/ __ \|  __ \ 
+##     _____  ____  _    _ _____   _____  ____  _____
+##   / ____|/ __ \| |  | |  __ \ / ____|/ __ \|  __ \
 ##  | (___ | |  | | |  | | |__) | (___ | |  | | |__) |
-##   \___ \| |  | | |  | |  _  / \___ \| |  | |  ___/ 
-##   ____) | |__| | |__| | | \ \ ____) | |__| | |     
-##  |_____/ \____/ \____/|_|  \_\_____/ \____/|_|     
+##   \___ \| |  | | |  | |  _  / \___ \| |  | |  ___/
+##   ____) | |__| | |__| | | \ \ ____) | |__| | |
+##  |_____/ \____/ \____/|_|  \_\_____/ \____/|_|
 
 ## Alex Holehouse (Pappu Lab and Holehouse Lab) and Jared Lalmansing (Pappu lab)
 ## Simulation analysis package
@@ -42,7 +42,7 @@ def _set_mkl_numpy_threads(mkl_path, num_threads):
     # Traditional UNIX-like systems will have shared objects available.
     if 'bsd' in sys.platform or 'lin' in sys.platform:
         mkl_rt = ctypes.CDLL(mkl_path)
-    
+
     # Darwin / Apple uses `*.dylib` by default for included Intel compiler libraries.
     # Traditional UNIX-like shared objects can be created (`*.so`), but are more
     # represented in third-party libraries. This is a more dynamic way of finding
@@ -91,7 +91,7 @@ def _identify_library_paths():
     # environments live across multiple OSes, and can be packaged in different
     # ways. Here we limit the results to Anaconda and regular Python environment
     # installations.
-    
+
     # Check existing environment variables and stop on the first match. The basis
     # for this approach is that only one should be active.
     virtualized_env = None
@@ -111,7 +111,7 @@ def _identify_library_paths():
         lib_paths = _locate_libraries(library)
         for lib_path in lib_paths:
             numpy_path_fragment = os.path.join('site-packages', 'numpy') # os-agnostic
-            if env_path is not None and env_path in lib_path and numpy_path_fragment in lib_path:
+            if virtualized_env is not None and virtualized_env in lib_path and numpy_path_fragment in lib_path:
                 candidates.append(lib_path)
             elif env_path in lib_path:
                 other_candidates.append(lib_path)
@@ -135,7 +135,7 @@ def _set_numpy_threads(candidate_library_paths, num_threads):
             library = 'unknown'
         break # stop on first set library
     return library, set_threads
-        
+
 
 def set_numpy_threads(num_threads):
     candidates, other_candidates = _identify_library_paths()
@@ -144,7 +144,7 @@ def set_numpy_threads(num_threads):
     else:
         set_threads, library = _set_numpy_threads(other_candidates, num_threads)
     return set_threads, library
-    
+
 
 def validate_keyword_option(keyword, allowed_vals, keyword_name, error_message=None):
     """

--- a/soursop/ssutils.py
+++ b/soursop/ssutils.py
@@ -16,8 +16,14 @@ import os
 import sys
 import numpy
 import ctypes
+import platform
+import warnings
 from . ssexceptions import SSException
 from threadpoolctl import threadpool_info, threadpool_limits
+
+
+MKL_LIBRARY = 'mkl_rt'
+OPENBLAS_LIBRARY = 'openblas'
 
 
 ##
@@ -26,7 +32,6 @@ from threadpoolctl import threadpool_info, threadpool_limits
 ## cores as it can get its greedy little hands on - this function allows that
 ## thirst to be quenched...
 ##
-
 def mkl_set_num_threads(cores):
     mkl_rt = ctypes.CDLL('libmkl_rt.so')
     mkl_get_max_threads = mkl_rt.mkl_get_max_threads()
@@ -34,7 +39,6 @@ def mkl_set_num_threads(cores):
 
 
 def _set_mkl_numpy_threads(mkl_path, num_threads):
-
     # Traditional UNIX-like systems will have shared objects available.
     if 'bsd' in sys.platform or 'lin' in sys.platform:
         mkl_rt = ctypes.CDLL(mkl_path)
@@ -59,32 +63,88 @@ def _set_openblas_numpy_threads(openblas_path, num_threads):
     return set_threads
 
 
-def set_numpy_threads(num_threads):
-    # Determine the BLAS implementation in use - e.g. MKL (Intel), OpenBLAS, etc.
-    info = threadpool_info()
+def _locate_libraries(library_name):
+    # Since `threadctl` is hit or miss on a Mac (especially for the latest versions),
+    # we have to do what the package does but in an ad-hoc manner using `locate`.
+    # This reasonably well in principle on both the Mac and on Linux. However, the
+    # requirement for `locatedb` may be a security issue for sensitive environments.
+    # But, for the vast majority of other use-cases, it should be sufficient.
+    import subprocess as sp
+    os_name = platform.system().lower()
+    if os_name == 'darwin':
+        libname = f"'*{library_name}*.dylib*'" # fuzzy match for locate
+    elif os_name == 'linux':
+        libname = f"'*{library_name}*.so*'"  # fuzzy match for locate
+    else:
+        warnings.warn(f'Unsupported OS: {os_name}.')
 
-    # Set the threads based on the library available.
+    proc = sp.Popen(['/usr/bin/locate', library_name], stdout=sp.PIPE, stderr=sp.PIPE)
+    lib_locations = list()
+    for line in proc.stdout:
+        loc = line.decode('utf-8').replace('\n', '').strip()
+        lib_locations.append(loc)
+    return lib_locations
+
+
+def _identify_library_paths():
+    # Identifying the right path and library to load is somewhat tricky as Python
+    # environments live across multiple OSes, and can be packaged in different
+    # ways. Here we limit the results to Anaconda and regular Python environment
+    # installations.
+    
+    # Check existing environment variables and stop on the first match. The basis
+    # for this approach is that only one should be active.
+    virtualized_env = None
+    for env_var in 'CONDA_DEFAULT_ENV,VIRTUAL_ENV'.split(','):
+        env_path = os.environ.get(env_var, None)
+        if env_path is not None:
+            virtualized_env = env_path
+            break
+
+    # Identify the library paths and split them into two:
+    # 1) candidates - these will be searched and attempted to be set first.
+    # 2) other candidates - backup library paths to check & set.
+    libraries = [MKL_LIBRARY, OPENBLAS_LIBRARY]
+    candidates = list()
+    other_candidates = list()
+    for library in libraries:
+        lib_paths = _locate_libraries(library)
+        for lib_path in lib_paths:
+            numpy_path_fragment = os.path.join('site-packages', 'numpy') # os-agnostic
+            if env_path is not None and env_path in lib_path and numpy_path_fragment in lib_path:
+                candidates.append(lib_path)
+            elif env_path in lib_path:
+                other_candidates.append(lib_path)
+    return candidates, other_candidates
+
+
+def _set_numpy_threads(candidate_library_paths, num_threads):
+    # This shadows the main entry point for setting the numpy threads. The libraries
+    # are set automatically on most *nix OSes.
     set_threads = 0
-    blas_implementation = None
-
-    for lib in info:
-        filepath = lib['filepath']
-        base_filepath = os.path.basename(filepath)
-        
-        if 'mkl' in base_filepath:
-            blas_implementation = 'mkl'
-            set_threads = _set_mkl_numpy_threads(filepath, num_threads)
-            break
-        
-        elif 'openblas' in base_filepath:
-            blas_implementation = 'openblas'
-            set_threads = _set_openblas_numpy_threads(filepath, num_threads)
-            break
-
+    library = None
+    for lib_path in candidate_library_paths:
+        if MKL_LIBRARY in lib_path:
+            set_threads = _set_mkl_numpy_threads(lib_path, num_threads)
+            library = MKL_LIBRARY
+        elif OPENBLAS_LIBRARY in lib_path:
+            set_threads = _set_openblas_numpy_threads(lib_path, num_threads)
+            library = OPENBLAS_LIBRARY
         else:
-            blas_implementation = 'unknown'
-    return blas_implementation, set_threads
+            warnings.warn('Unsupported library. Please install OPENBLAS or the Intel MKL library. No threads set.')
+            library = 'unknown'
+        break # stop on first set library
+    return library, set_threads
+        
 
+def set_numpy_threads(num_threads):
+    candidates, other_candidates = _identify_library_paths()
+    if len(candidates) > 0:
+        set_threads, library = _set_numpy_threads(candidates, num_threads)
+    else:
+        set_threads, library = _set_numpy_threads(other_candidates, num_threads)
+    return set_threads, library
+    
 
 def validate_keyword_option(keyword, allowed_vals, keyword_name, error_message=None):
     """


### PR DESCRIPTION
BACKGROUND

This Pull Request fixes a previous issue with setting the number of threads for numpy (`ssutils.set_numpy_threads`). That function is crucial as by default Numpy will attempt to use as many threads as possible which can make a multiprocessing pipeline rather slow.

Although the max threads can be set prior to launching the tests and scripts via environment variables, ([Ref 1](https://stackoverflow.com/questions/30791550/limit-number-of-threads-in-numpy)), setting that value cannot be easily done on the fly in an easy-to-use manner. This is especially important in cases where other libraries use numpy and are imported ([Ref 2](https://github.com/numpy/numpy/issues/11826)). [Threadpoolctl](https://github.com/joblib/threadpoolctl) is the suggested solution for this problem as it is known for managing Numpy threads in a contextual manner using a `with` statement. 

Consequently, the previous version used `threadpoolctl` for obtaining the information about the existing libraries. However, it appears that recent OS updates have broken this functionality on the Mac. As we want to set the number of threads globally and somewhat easily, a new approach was devised.

REVISION

In light of that, this revision does the following:

1. Identifies the existing libraries using `locate` (a *nix command). Consequently, this currently only works on the Mac and Linux - a Windows version needs further work.
2. Determine how the libraries should be loaded based on whether the user is running the code in a virtualized environment (i.e. Python virtualenv or an Anaconda environment). MKL or OPENBLAS paths are prioritized based on whether they are installed in the active virtualized environment. Other paths are only used as backup.

CAVEATS

As a consequence of item 1, the resulting unittest is somewhat slow (between 7 - 14 seconds), however once one knows what libraries exist, that information can be cached for future calls. Moreover, as this work-around relies on the **mlocate.db** (referenced by the `locate` command), that could be a concern in secure environments. However, it should be sufficient for most cases. Future versions will attempt to mitigate that issue.

EVALUATION

To evaluate the unittest with `pytest`, do: `pytest --capture=sys test_ssutils.py::test_set_numpy_threads`.

TODO

1. Adapt current approach for use on Windows.
2. Cache results and implement a secure alternative to `locate`.