### PR TITLE
molecular volume implementation via convex hull

### DIFF
--- a/soursop/ssprotein.py
+++ b/soursop/ssprotein.py
@@ -16,6 +16,7 @@ from numpy import linalg as LA
 from itertools import combinations
 from scipy import stats
 import scipy.optimize as SPO
+from scipy.spatial import ConvexHull
 from numpy.random import choice
 from .configs import DEBUGGING
 from .ssdata import THREE_TO_ONE, DEFAULT_SIDECHAIN_VECTOR_ATOMS, ALL_VALID_RESIDUE_NAMES
@@ -2751,6 +2752,32 @@ class SSProtein:
         Rg_over_Rh = ((alpha1*(rg - alpha2*N_033)) / (N_060 - N_033)) + alpha3
 
         return (1/Rg_over_Rh)*rg
+
+    # ........................................................................
+    #
+    #
+    def get_molecular_volume(self, **kwargs):
+        """
+        Returns the molecular volume of a macromolecule at all frames in a trajectory. 
+
+        Molecular volume is returned in Angstroms^3.
+
+        Parameters
+        ---------------
+        kwargs : optional
+            Keyword arguments are passed into scipy's ConvexHull function
+
+        Returns
+        -----------
+        np.ndarray
+            Returns a numpy array with per-frame instantaneous molecular volume in A^3
+
+        """
+        NM_TO_ANGSTROM = 1000 # 1000 A^3 / nm^3
+        
+        # in angstroms
+        volumes = np.array([ConvexHull(xyz,**kwargs).volume for xyz in self.traj.xyz])*NM_TO_ANGSTROM
+        return volumes
 
 
     # ........................................................................

--- a/soursop/tests/test_ssproteins.py
+++ b/soursop/tests/test_ssproteins.py
@@ -110,6 +110,7 @@ def test_get_radius_of_gyration(GS6_CP):
     assert abs(GS6_CP.get_radius_of_gyration()[0] - 5.728453763896514) < 0.0001
     assert abs(GS6_CP.get_radius_of_gyration(R1=1,R2=3)[0] - 2.8815625777553278) < 0.0001
 
+
 def test_get_t(GS6_CP):
 
     assert len(GS6_CP.get_t()) == 5
@@ -191,12 +192,21 @@ def test_get_distance_map(GS6_CO):
         assert np.allclose(distance_map, np.triu(distance_map)) is True
 
 
-
 def test_get_hydrodynamic_radius(GS6_CO):
 
     CP = GS6_CO.proteinTrajectoryList[0]
     rh = CP.get_hydrodynamic_radius()
     assert (11.840569781179006 - rh[0]) < 0.001
+
+def test_get_molecular_volume(NTL9_CO):
+
+    CP = NTL9_CO.proteinTrajectoryList[0]
+    mol_vol = CP.get_molecular_volume()
+    assert len(mol_vol) == 10
+    assert mol_vol[0] - 20839.78797511 < 0.0000001
+    assert np.mean(mol_vol) - 24064.633461433674 < 0.0000001
+
+
 
 
 # ====


### PR DESCRIPTION
## Description
Implementation of molecular volumes via scipy's ConvexHall in the `SSprotein` class via `.get_molecular_volume()` - b/c I was bored and wanted to read about this after JJ asked for a method and I figured it might be convenient / useful for someone else down the line.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] added functionality and unit tests
  - [x] all tests pass

## Questions
- [ ] I converted the volume from what I presume is nm^3 to A^3? mdtraj does everything in nanometers and soursop has convention to operate in A, correct?

## Status
- [x] Ready to go