### PR TITLE
return kr as np.array consistent with nygaard

### DIFF
--- a/soursop/ssprotein.py
+++ b/soursop/ssprotein.py
@@ -2933,9 +2933,7 @@ class SSProtein:
 
             # finally, take per-frame inverse of the inverse distance
             # to get Rh
-            Rh = []
-            for f in all_rij:
-                Rh.append(1/np.mean(f))
+            Rh = np.reciprocal(np.mean(all_rij, axis=1).astype(float))
 
             return Rh
         


### PR DESCRIPTION
## Description
`.get_hydrodynamic_radius()` in the `SSProtein` class previously returned a numpy array for the Nygaard implementation of the Rh computation. The recently implemented Kirkwood-riseman mode currently returns a list. 

This PR makes the function call return type consistent between modes - e.g., I just vectorized the last step of the Rh calculation and returned the final result as a `np.array`

## Status
- [x] Ready to go